### PR TITLE
Ph/parallel performance

### DIFF
--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -48,7 +48,7 @@ module MiniAutobot
         if run_on_mac?
           @simultaneous_jobs = 10 # saucelabs account limit for parallel is 10 for mac
         else
-          @simultaneous_jobs = 15 # saucelabs account limit for parallel is 15 for non-mac
+          @simultaneous_jobs = 40 # saucelabs account limit for parallel is 15 for non-mac
         end
       end
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -79,23 +79,23 @@ module MiniAutobot
       end
     end
 
+    # recursively keep running #{simultaneous_jobs} number of tests in parallel
+    # exit when no test left to run
     def keep_running_full(all_to_run)
-      puts "simultaneous_jobs = #{simultaneous_jobs}"
       running_subprocess_count = count_autobot_process - 1 # minus parent process
+      puts "WARNING: running_subprocess_count = #{running_subprocess_count}
+            is more than what it is supposed to run(#{simultaneous_jobs}),
+            notify mini_autobot maintainers" if running_subprocess_count > simultaneous_jobs
       while running_subprocess_count >= simultaneous_jobs
-        puts "running_subprocess_count = #{running_subprocess_count} >= simultaneous_jobs = #{simultaneous_jobs}, wait 5 sec"
         sleep 5
         running_subprocess_count = count_autobot_process - 1
       end
       to_run_count = simultaneous_jobs - running_subprocess_count
-      puts "got some space, run #{to_run_count} more"
       tests_to_run = all_to_run.slice!(0, to_run_count)
+
       run_test_set(tests_to_run)
-      if all_to_run.size > 0
-        keep_running_full(all_to_run)
-      else
-        return
-      end
+
+      keep_running_full(all_to_run) if all_to_run.size > 0
     end
 
     # @deprecated Use more native wait/check of Process

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -48,7 +48,7 @@ module MiniAutobot
         if run_on_mac?
           @simultaneous_jobs = 10 # saucelabs account limit for parallel is 10 for mac
         else
-          @simultaneous_jobs = 40 # saucelabs account limit for parallel is 15 for non-mac
+          @simultaneous_jobs = 20 # saucelabs account limit for parallel is 15 for non-mac
         end
       end
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -65,8 +65,7 @@ module MiniAutobot
         keep_running_full(all_to_run)
       end
 
-      wait_all_done_saucelabs if @on_sauce
-      wait_for_pids(@pids) unless ENV['JENKINS_HOME']
+      Process.waitall
       puts "\nAll Complete! Started at #{@start_time} and finished at #{Time.now}\n"
       exit
     end
@@ -100,7 +99,6 @@ module MiniAutobot
         run_command = "#{@static_run_command} -n #{test} #{@pipe_tap} > logs/tap_results/#{test}.t"
         pipe = IO.popen(run_command)
         puts "Running #{test}  #{pipe.pid}"
-        @pids << pipe.pid
       end
     end
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -23,8 +23,7 @@ module MiniAutobot
     # return true only if specified to run on mac in connector
     # @return [boolean]
     def run_on_mac?
-      return true if @platform.include?('osx')
-      return false
+      @platform.include?('osx')
     end
 
     # remove all results files under logs/tap_results/
@@ -34,9 +33,8 @@ module MiniAutobot
     end
 
     def count_autobot_process
-      counting_process = IO.popen "ps -ef | grep 'bin/#{@static_run_command}' -c"
-      count_of_processes = counting_process.readlines[0].to_i - 1 # minus grep process
-      count_of_processes
+      counting_process_output = IO.popen "ps -ef | grep 'bin/#{@static_run_command}' -c"
+      counting_process_output.readlines[0].to_i - 1 # minus grep process
     end
 
     # run multiple commands with logging to start multiple tests in parallel
@@ -85,7 +83,7 @@ module MiniAutobot
       running_subprocess_count = count_autobot_process - 1 # minus parent process
       puts "WARNING: running_subprocess_count = #{running_subprocess_count}
             is more than what it is supposed to run(#{simultaneous_jobs}),
-            notify mini_autobot maintainers" if running_subprocess_count > simultaneous_jobs
+            notify mini_autobot maintainers" if running_subprocess_count > simultaneous_jobs + 1
       while running_subprocess_count >= simultaneous_jobs
         sleep 5
         running_subprocess_count = count_autobot_process - 1


### PR DESCRIPTION
#### Parallelization Performance Improvements
1. Process.waitall instead of my own way wait_for_pids for better performance.
   Make sure it works on jenkins since there were some problems with #wait_for_pids when it's running on a jenkins slave machine.
2. `#keep_running_full` is not doing what it's supposed to do recently, probably due to wrong count of running subprocesses, inspect and fix.
3. Change default parallel number from 15 to 20.
