### PR TITLE
Ph/set sauce job status

### DIFF
--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -27,9 +27,9 @@ module MiniAutobot
       @platform.include?('osx')
     end
 
-    # remove all results files under logs/tap_results/
+    # remove all results files under logs/tap_results/ if there's any
     def clean_result!
-      IO.popen 'rm logs/tap_results/*'
+      FileUtils.rm_rf(Dir.glob('logs/tap_results/*')) unless Dir.glob('logs/tap_results/*').empty?
       puts "Cleaning result files.\n"
     end
 

--- a/lib/mini_autobot/version.rb
+++ b/lib/mini_autobot/version.rb
@@ -1,3 +1,3 @@
 module MiniAutobot
-  VERSION = '0.0.7'
+  VERSION = '0.0.8'
 end


### PR DESCRIPTION
[PH][102086106] Set SauceLabs job status after test complete

Instead of using SauceWhisk gem, I went with directly calling saucelabs rest APIs, combined it with an existing api call which updates sauce session's name and tag after test complete.

Also did some cleanup for paralle.rb so it uses FileUtils instead of opening a subprocess and do stuffs in shell.

0.0.8 tagged and released.
