### PR TITLE
Ph/parallelize arbitrary test set

### DIFF
--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -1,43 +1,8 @@
 module MiniAutobot
-  class Runnable < Minitest::Runnable
-
-    ##
-    # Defines the order to run tests (:random by default). Override
-    # this or use a convenience method to change it for your tests.
-
-    def self.test_order
-      :random
-    end
-
-    ##
-    # Responsible for running all runnable methods in a given class,
-    # each in its own instance. Each instance is passed to the
-    # reporter to record.
-
-    def self.start_run reporter, options = {}
-      filter = options[:filter] || '/./'
-      filter = Regexp.new $1 if filter =~ /\/(.*)\//
-
-      filtered_methods = Minitest::Test.runnable_methods.find_all { |m|
-        filter === m || filter === "#{self}##{m}"
-      }
-
-      Minitest::Test.with_info_handler reporter do
-        filtered_methods.each do |method_name|
-          if MiniAutobot.settings.parallel?
-            @@parallelized_methods << method_name
-          else
-            run_one_method self, method_name, reporter
-          end
-        end
-      end
-    end
-  end
   class Runner
 
     attr_accessor :options
     @after_hooks = []
-    @@parallelized_methods = []
 
     def self.after_run(&blk)
       @after_hooks << blk
@@ -65,34 +30,11 @@ module MiniAutobot
       Minitest.reporter = nil # runnables shouldn't depend on the reporter, ever
 
       reporter.start
-      # parallel execution starts here, instead of this __run below?
-      self.__run reporter, @options
-      require 'pry'
-      binding.pry
+      Minitest.__run reporter, @options
       Minitest.parallel_executor.shutdown
       reporter.report
 
       reporter.passed?
-    end
-
-    ##
-    # Internal run method. Responsible for telling all Runnable
-    # sub-classes to run.
-    #
-    # NOTE: this method is redefined in parallel_each.rb, which is
-    # loaded if a Runnable calls parallelize_me!.
-
-    def self.__run reporter, options
-      suites = MiniAutobot::Runnable.runnables.shuffle
-      parallel, serial = suites.partition { |s| s.test_order == :parallel }
-
-      # If we run the parallel tests before the serial tests, the parallel tests
-      # could run in parallel with the serial tests. This would be bad because
-      # the serial tests won't lock around Reporter#record. Run the serial tests
-      # first, so that after they complete, the parallel tests will lock when
-      # recording results.
-      serial.map { |suite| suite.start_run reporter, options } +
-          parallel.map { |suite| suite.start_run reporter, options }
     end
 
     # before hook where you have parsed @options when loading tests

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -6,7 +6,6 @@ module MiniAutobot
     @@selected_methods = []
     @@runnables_count = 0
     @@regression_suite = Array.new
-    @@already_executed = false
     @@serials = Array.new
     @@test_suite_data = if File.exist?(MiniAutobot.root.join("config/mini_autobot/test_suite.yml"))
                           YAML.load_file(MiniAutobot.root.join("config/mini_autobot/test_suite.yml"))

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -83,8 +83,23 @@ module MiniAutobot
         filtered_methods = filter_methods(methods, selected)
 
         if MiniAutobot.settings.parallel
-          parallel = Parallel.new(MiniAutobot.settings.parallel, @@selected_methods)
-          parallel.run_in_parallel!
+          unless filtered_methods.empty?
+            if selected.nil? || selected.empty?
+              @@selected_methods = @@regression_suite
+            else
+              methods_to_add = filtered_methods.map { |method| method.to_sym if @@regression_suite.include?(method.to_sym) }
+              @@selected_methods += methods_to_add
+            end
+          end
+
+          @@runnables_count += 1
+          if @@runnables_count == @@runnables.size - 2
+            parallel = Parallel.new(MiniAutobot.settings.parallel, @@selected_methods)
+            parallel.run_in_parallel!
+            exit
+          end
+
+          return [] # no test will run
         else
           filtered_methods
         end

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -3,6 +3,7 @@ module MiniAutobot
   # An MiniAutobot-specific test case container, which extends the default ones,
   # adds convenience helper methods, and manages page objects automatically.
   class TestCase < Minitest::Test
+    @@selected_methods = []
     @@regression_suite = Array.new
     @@already_executed = false
     @@serials = Array.new
@@ -93,7 +94,7 @@ module MiniAutobot
         # If no tags are selected, run all tests
         return methods if selected.nil? || selected.empty?
 
-        return methods.select do |method|
+        selected_methods = methods.select do |method|
           # If the method's tags match any of the tag sets, allow it to run
           selected.any? do |tag_set|
             # Retrieve the tags for that method
@@ -111,6 +112,8 @@ module MiniAutobot
             end
           end
         end
+        @@selected_methods += selected_methods unless selected_methods.empty?
+        return selected_methods
       end
 
       # Install a setup method that runs before every test.
@@ -179,6 +182,9 @@ module MiniAutobot
           @@regression_suite << method_name
           @@serials << opts[:serial]
         end
+
+        # get a list of non_regression tests
+        # store it in a class variable
       end
 
       # @param suite [String] type of test suite

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -113,6 +113,7 @@ module MiniAutobot
           end
         end
         @@selected_methods += selected_methods unless selected_methods.empty?
+        @@selected_methods - @@selected_methods.select { |method| !@@regression_suite.include?(method) }
         return selected_methods
       end
 


### PR DESCRIPTION
#### [PH][102526414] [Parallelize any arbitrary subset of tests](https://www.pivotaltracker.com/story/show/102526414)
##### The most straightforward way - get a list of selected methods, then call parallel to run them.
##### The goal:

Run any arbitrary set of tests in parallel, instead of only being able to run whole regression suite in parallel, basically enable command line option `--parallel=n` to work in conjunction with tests filter option `-t tag_of_some_tests`.
##### The solution:

Filter methods before parallel run to prepare filtered methods to be accessible for parallel.
Then, if it's parallel run, only add these filtered methods to a list of to run methods instead of running them one by one right away, and finally when all runnable methods are traversed, call parallel to run that list of methods.
