### PR TITLE
Ph/rerun failing tests

### DIFF
--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -17,6 +17,9 @@ module MiniAutobot
 
       @pids = []
       @static_run_command = "mini_autobot -c #{MiniAutobot.settings.connector} -e #{MiniAutobot.settings.env}"
+      if MiniAutobot.settings.rerun_failure
+        @static_run_command += " -R #{MiniAutobot.settings.rerun_failure}"
+      end
       tap_reporter_path = MiniAutobot.gem_root.join('lib/tapout/custom_reporters/fancy_tap_reporter.rb')
       @pipe_tap = "--tapy | tapout --no-color -r #{tap_reporter_path.to_s} fancytap"
     end

--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -24,10 +24,12 @@ module MiniAutobot
 
       reporter = self.single_run
 
-      @@run_count += 1
-      rerun = 1
-      unless reporter.passed? && @@run_count > rerun
-        reporter = self.single_run
+      if @options[:rerun_failure]
+        @@run_count += 1
+        rerun = 1
+        unless reporter.passed? && @@run_count > rerun
+          reporter = self.single_run
+        end
       end
       
       reporter.report

--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -31,8 +31,6 @@ module MiniAutobot
           @@rerun_count += 1
         end
       end
-      
-      reporter.report
 
       reporter.passed?
     end
@@ -51,6 +49,7 @@ module MiniAutobot
       reporter.start
       Minitest.__run reporter, @options
       Minitest.parallel_executor.shutdown
+      reporter.report
 
       reporter
     end

--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -26,7 +26,7 @@ module MiniAutobot
 
       rerun_failure = @options[:rerun_failure]
       if rerun_failure && !reporter.passed?
-        while @@rerun_count < rerun_failure
+        while @@rerun_count < rerun_failure && !reporter.passed?
           reporter = self.single_run
           @@rerun_count += 1
         end

--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -21,18 +21,25 @@ module MiniAutobot
       @options = Minitest.process_args args
 
       self.before_run
+      require 'pry'
+      binding.pry
+      # reporter = self.single_run
+      #
+      # rerun_failure = @options[:rerun_failure]
+      # if rerun_failure && !reporter.passed?
+      #   while @@rerun_count < rerun_failure && !reporter.passed?
+      #     reporter = self.single_run
+      #     @@rerun_count += 1
+      #   end
+      # end
+      t = Thread.new { self.single_run }
+      require 'pry'
+      binding.pry
+      t.join
+      reporter = t.value
+      puts "all_results = #{t['all_results']}"
 
-      reporter = self.single_run
-
-      rerun_failure = @options[:rerun_failure]
-      if rerun_failure && !reporter.passed?
-        while @@rerun_count < rerun_failure && !reporter.passed?
-          reporter = self.single_run
-          @@rerun_count += 1
-        end
-      end
-      
-      reporter.report
+      reporter.report # tapy - type: final
 
       reporter.passed?
     end

--- a/lib/mini_autobot/runner.rb
+++ b/lib/mini_autobot/runner.rb
@@ -3,7 +3,7 @@ module MiniAutobot
 
     attr_accessor :options
     @after_hooks = []
-    @@run_count = 1
+    @@rerun_count = 0
 
     def self.after_run(&blk)
       @after_hooks << blk
@@ -24,11 +24,11 @@ module MiniAutobot
 
       reporter = self.single_run
 
-      if @options[:rerun_failure]
-        @@run_count += 1
-        rerun = 1
-        unless reporter.passed? && @@run_count > rerun
+      rerun_failure = @options[:rerun_failure]
+      if rerun_failure && !reporter.passed?
+        while @@rerun_count < rerun_failure
           reporter = self.single_run
+          @@rerun_count += 1
         end
       end
       

--- a/lib/mini_autobot/settings.rb
+++ b/lib/mini_autobot/settings.rb
@@ -60,6 +60,14 @@ module MiniAutobot
       hsh.fetch(:reuse_driver, false)
     end
 
+    def rerun_failure
+      if hsh.fetch(:rerun_failure)
+        hsh.fetch(:rerun_failure)
+      else
+        return 0
+      end
+    end
+
     def seed
       hsh.fetch(:seed, nil).to_i
     end

--- a/lib/mini_autobot/settings.rb
+++ b/lib/mini_autobot/settings.rb
@@ -61,11 +61,7 @@ module MiniAutobot
     end
 
     def rerun_failure
-      if hsh.fetch(:rerun_failure)
-        hsh.fetch(:rerun_failure)
-      else
-        return 0
-      end
+      hsh.fetch(:rerun_failure)
     end
 
     def seed

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -58,8 +58,8 @@ module MiniAutobot
       # @return [void]
       def teardown
         if !passed? && !skipped? && !@driver.nil?
-          take_screenshot
           save_to_ever_failed if MiniAutobot.settings.rerun_failure
+          take_screenshot
           print_sauce_link if connector_is_saucelabs?
         end
         begin
@@ -84,7 +84,7 @@ module MiniAutobot
           existing_failed_tests = File.readlines(ever_failed_tests).map do |line|
             line.delete "\n"
           end
-          f.puts "#{name}" unless existing_failed_tests.include? name
+          f.puts name unless existing_failed_tests.include? name
         end
       end
 

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -81,7 +81,10 @@ module MiniAutobot
       def save_to_ever_failed
         ever_failed_tests = 'logs/tap_results/ever_failed_tests'
         File.open(ever_failed_tests, 'a') do |f|
-          f.puts name unless File.readlines(ever_failed_tests).grep(/#{name}/).any?
+          existing_failed_tests = File.readlines(ever_failed_tests).map do |line|
+            line.delete "\n"
+          end
+          f.puts "#{name}" unless existing_failed_tests.include? name
         end
       end
 

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -59,6 +59,7 @@ module MiniAutobot
       def teardown
         if !passed? && !skipped? && !@driver.nil?
           take_screenshot
+          save_to_ever_failed if MiniAutobot.settings.rerun_failure
           print_sauce_link if connector_is_saucelabs?
         end
         begin
@@ -74,6 +75,14 @@ module MiniAutobot
 
       def take_screenshot
         @driver.save_screenshot("logs/#{name}.png")
+      end
+
+      # Save test name to ever_failed_tests file only for the first time it failed
+      def save_to_ever_failed
+        ever_failed_tests = 'logs/tap_results/ever_failed_tests'
+        File.open(ever_failed_tests, 'a') do |f|
+          f.puts name unless File.readlines(ever_failed_tests).grep(/#{name}/).any?
+        end
       end
 
       # Print out a link of a saucelabs's job when a test is not passed

--- a/lib/minitap/minitest5_rent.rb
+++ b/lib/minitap/minitest5_rent.rb
@@ -7,11 +7,7 @@ module Minitest
   #
   class Minitap
 
-    attr_accessor :all_results
-
     def tapout_before_case(test_case)
-      all_results << 'results123'
-      Thread.current['all_results'] = all_results
       doc = {
           'type'    => 'case',
           'subtype' => '',

--- a/lib/minitap/minitest5_rent.rb
+++ b/lib/minitap/minitest5_rent.rb
@@ -7,7 +7,11 @@ module Minitest
   #
   class Minitap
 
+    attr_accessor :all_results
+
     def tapout_before_case(test_case)
+      all_results << 'results123'
+      Thread.current['all_results'] = all_results
       doc = {
           'type'    => 'case',
           'subtype' => '',

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -74,8 +74,9 @@ module Minitest
     end
 
     options[:rerun_failure] = false
-    parser.on('-R', '--rerun-failure', "Rerun failing test") do |value|
-      options[:rerun_failure] = value
+    parser.on('-R', '--rerun-failure [RERUN]', 'Rerun failing test; If enabled, can set number of times to rerun') do |value|
+      integer_value = value.nil? ? 1 : value.to_i
+      options[:rerun_failure] = integer_value
     end
   end
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -72,6 +72,11 @@ module Minitest
     parser.on('-P', '--parallel PARALLEL', 'Run any number of tests in parallel') do |value|
       options[:parallel] = value
     end
+
+    options[:rerun_failure] = false
+    parser.on('-R', '--rerun-failure', "Rerun failing test") do |value|
+      options[:rerun_failure] = value
+    end
   end
 
 end


### PR DESCRIPTION
[[PH][104191480] Optional Rerun Failing Tests](https://www.pivotaltracker.com/story/show/104191480)
#### Optional Rerun Failing Tests
##### Goal

For regression run or other test runs which have results that teams want to depend on, it's critical that the results are trustworthy, so rerun failing tests serves as a way to improve its credibility. While during tests development or debugging, it should be disabled so user can see test failure immediately.
##### Usage

When running tests from command line, use option `-R` or `--rerun-failure`, it'll rerun tests if there's any failure from this run, default rerun up to once, can optionally specify a number value for it, eg. `-R 2` means rerun up to 2 times (if it failed consecutively).
##### Final Thoughts

Currently, when rerun feature is enabled, it'll rerun the whole run if there's any failure, eg.
`be mini_autobot -c firefox -e rent_qa -t critical_path -R` will rerun all `-t critical_path` tests if there's only one test failed, which is not very time efficient, but it simplifies things from test result reporter's standpoint - all runs are done within the same process, initialize a new reporter for every new run, the code for result aggregation stays untouched so counting will not go wrong. Otherwise, it would need to open new processes/threads to run individual failing tests, grab the results and come back to the parent process and merge the results with other tests in the run.
