### PR TITLE
Ph/update sauce session

### DIFF
--- a/lib/mini_autobot.rb
+++ b/lib/mini_autobot.rb
@@ -11,7 +11,7 @@ require 'erb'
 require 'faker'
 require 'selenium/webdriver'
 require 'rest-client'
-
+require 'json'
 require 'cgi'
 require 'pathname'
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -125,8 +125,6 @@ module MiniAutobot
       username = MiniAutobot.settings.sauce_username
       access_key = MiniAutobot.settings.sauce_access_key
 
-      require 'json'
-
       # call api to get most recent #{limit} jobs' ids
       http_auth = "https://#{username}:#{access_key}@saucelabs.com/rest/v1/#{username}/jobs?limit=#{limit}"
       response = get_response_with_retry(http_auth) # response was originally an array of hashs, but RestClient converts it to a string

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -122,17 +122,8 @@ module MiniAutobot
     # call saucelabs REST API to get last #{limit} jobs' statuses
     # possible job status: complete, error, in progress
     def saucelabs_last_n_statuses(limit)
-      connector = MiniAutobot.settings.connector # eg. saucelabs:phu:win7_ie11
-      overrides = connector.to_s.split(/:/)
-      file_name = overrides.shift
-      path = MiniAutobot.root.join('config/mini_autobot', 'connectors')
-      filepath  = path.join("#{file_name}.yml")
-      raise ArgumentError, "Cannot load profile #{file_name.inspect} because #{filepath.inspect} does not exist" unless filepath.exist?
-      cfg = YAML.load(File.read(filepath))
-      cfg = Connector.resolve(cfg, overrides)
-      cfg.freeze
-      username = cfg["hub"]["user"]
-      access_key = cfg["hub"]["pass"]
+      username = MiniAutobot.settings.sauce_username
+      access_key = MiniAutobot.settings.sauce_access_key
 
       require 'json'
 

--- a/lib/mini_autobot/settings.rb
+++ b/lib/mini_autobot/settings.rb
@@ -33,6 +33,19 @@ module MiniAutobot
       hsh.fetch(:env, :rent_qa).to_s
     end
 
+    def sauce_session_http_auth(driver)
+      session_id = driver.session_id
+      "https://#{sauce_username}:#{sauce_access_key}@saucelabs.com/rest/v1/#{sauce_username}/jobs/#{session_id}"
+    end
+
+    def sauce_username
+      sauce_user["user"]
+    end
+
+    def sauce_access_key
+      sauce_user["pass"]
+    end
+
     def io
       hsh[:io]
     end
@@ -82,6 +95,19 @@ module MiniAutobot
 
     private
     attr_reader :hsh
+
+    def sauce_user
+      overrides = connector.split(/:/)
+      file_name = overrides.shift
+      path = MiniAutobot.root.join('config/mini_autobot', 'connectors')
+      filepath  = path.join("#{file_name}.yml")
+      raise ArgumentError, "Cannot load profile #{file_name.inspect} because #{filepath.inspect} does not exist" unless filepath.exist?
+
+      cfg = YAML.load(File.read(filepath))
+      cfg = Connector.resolve(cfg, overrides)
+      cfg.freeze
+      cfg["hub"]
+    end
 
   end
 

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -131,7 +131,7 @@ module MiniAutobot
       # Update SauceLabs session(job) name
       def update_sauce_session_name
         require 'json'
-        http_auth = sauce_http_auth
+        http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
         body = { "name" => name() }
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})
       end
@@ -139,27 +139,9 @@ module MiniAutobot
       # Update session(job) status if test is not skipped
       def update_sauce_session_status
         require 'json'
-        http_auth = sauce_http_auth
+        http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
         body = { "passed" => passed? }
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})
-      end
-
-      def sauce_http_auth
-        connector = MiniAutobot.settings.connector # eg. saucelabs:phu:win7_ie11
-        overrides = connector.to_s.split(/:/)
-        file_name = overrides.shift
-        path = MiniAutobot.root.join('config/mini_autobot', 'connectors')
-        filepath  = path.join("#{file_name}.yml")
-        raise ArgumentError, "Cannot load profile #{file_name.inspect} because #{filepath.inspect} does not exist" unless filepath.exist?
-
-        cfg = YAML.load(File.read(filepath))
-        cfg = Connector.resolve(cfg, overrides)
-        cfg.freeze
-        username = cfg["hub"]["user"]
-        access_key = cfg["hub"]["pass"]
-
-        session_id = @driver.session_id
-        http_auth = "https://#{username}:#{access_key}@saucelabs.com/rest/v1/#{username}/jobs/#{session_id}"
       end
 
       def connector_is_saucelabs?

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -130,7 +130,6 @@ module MiniAutobot
 
       # Update SauceLabs session(job) name
       def update_sauce_session_name
-        require 'json'
         http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
         body = { "name" => name() }
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})
@@ -138,7 +137,6 @@ module MiniAutobot
 
       # Update session(job) status if test is not skipped
       def update_sauce_session_status
-        require 'json'
         http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
         body = { "passed" => passed? }
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -31,6 +31,13 @@ module MiniAutobot
         @driver = override_driver if !override_driver.nil?
         instance = klass.new(@driver)
 
+        # Set SauceLabs session(job) name to test's name if running on Saucelabs
+        begin
+          update_sauce_session_name if connector_is_saucelabs? && !@driver.nil?
+        rescue
+          self.logger.debug "Failed setting saucelabs session name for #{name()}"
+        end
+
         # Before visiting the page, do any pre-processing necessary, if any,
         # but only visit the page if the pre-processing succeeds
         if block_given?
@@ -62,11 +69,9 @@ module MiniAutobot
           take_screenshot
         end
         begin
-          update_sauce_session_name if connector_is_saucelabs? && !@driver.nil?
           update_sauce_session_status if connector_is_saucelabs? && !@driver.nil? && !skipped?
-          self.logger.debug "Finished setting saucelabs session name for #{name()}"
         rescue
-          self.logger.debug "Failed setting saucelabs session name for #{name()}"
+          self.logger.debug "Failed setting saucelabs session status for #{name()}"
         end
 
         MiniAutobot::Connector.finalize!


### PR DESCRIPTION
[[PH][110532454] MiniAutobot: Set Saucelabs Test Session Name Earlier](https://www.pivotaltracker.com/story/show/110532454)
1. Split `update_sauce_session` to update name and status separately, and abstract accessors of saucelabs http auth url, username and access key to `MiniAutobot.settings`;
2. Set sauce session name right after driver initialized on Saucelabs instead of setting it during page teardown;
3. Cleanup for parallel.rb.

[[PH][110780540] MiniAutobot: `require 'json'`](https://www.pivotaltracker.com/story/show/110780540)
require 'json' for the whole mini_autobot instead of only at specific places.
