### PR TITLE
Ph/pass jenkins build num to sauce

### DIFF
--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -128,10 +128,10 @@ module MiniAutobot
         end
       end
 
-      # Update SauceLabs session(job) name
+      # Update SauceLabs session(job) name and build number/name
       def update_sauce_session_name
         http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
-        body = { "name" => name() }
+        body = { "name" => name(), "build" => ENV['JENKINS_BUILD_NUMBER'] }
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})
       end
 

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -131,7 +131,10 @@ module MiniAutobot
       # Update SauceLabs session(job) name and build number/name
       def update_sauce_session_name
         http_auth = MiniAutobot.settings.sauce_session_http_auth(@driver)
-        body = { "name" => name(), "build" => ENV['JENKINS_BUILD_NUMBER'] }
+        body = { 'name' => name() }
+        unless (build_number = ENV['JENKINS_BUILD_NUMBER']).nil?
+          body['build'] = build_number
+        end
         RestClient.put(http_auth, body.to_json, {:content_type => "application/json"})
       end
 


### PR DESCRIPTION
[[PH][111450944]Ph/pass jenkins build num to sauce](https://www.pivotaltracker.com/story/show/111450944)

Pass jenkins build number to SauceLabs during page initialization, and only do this when the build number exists - DO NOT set build number when triggering tests from local machines.
