### PR TITLE
Jt/add safe click method

### DIFF
--- a/lib/mini_autobot.rb
+++ b/lib/mini_autobot.rb
@@ -33,6 +33,7 @@ require 'active_support/inflector'
 require 'active_support/logger'
 
 require_relative 'minitap/minitest5_rent'
+require_relative 'selenium/webdriver/common/element_mini'
 
 ActiveSupport::Inflector.inflections(:en) do |inflector|
   inflector.acronym 'PDP'

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -258,13 +258,13 @@ module MiniAutobot
 
       # Method that overrides click to send the enter key to the element if the current browser
       # is internet explorer. Used when sending the enter key to the element will work
-      def ie_safe_click(element)
+      def browser_safe_click(element)
         driver.browser == :internet_explorer ? element.send_keys(:enter) : element.click
       end
 
       # Method that overrides click to send the space key to the checkbox if the current browser
       # is internet explorer. Used when sending the space key to the checkbox will work
-      def ie_safe_checkbox_click(element)
+      def browser_safe_checkbox_click(element)
         driver.browser == :internet_explorer ? element.send_keys(:space) : element.click
       end
 

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -265,7 +265,7 @@ module MiniAutobot
       # Method that overrides click to send the space key to the checkbox if the current browser
       # is internet explorer. Used when sending the space key to the checkbox will work
       def browser_safe_checkbox_click(element)
-        (bridge.browser == :internet_explorer || bridge.browser == :firefox) ? element.send_keys(:space) : element.click
+        (driver.browser == :internet_explorer || driver.browser == :firefox) ? element.send_keys(:space) : element.click
       end
 
     end

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -265,7 +265,7 @@ module MiniAutobot
       # Method that overrides click to send the space key to the checkbox if the current browser
       # is internet explorer. Used when sending the space key to the checkbox will work
       def browser_safe_checkbox_click(element)
-        driver.browser == :internet_explorer ? element.send_keys(:space) : element.click
+        (bridge.browser == :internet_explorer || bridge.browser == :firefox) ? element.send_keys(:space) : element.click
       end
 
     end

--- a/lib/mini_autobot/utils/page_object_helper.rb
+++ b/lib/mini_autobot/utils/page_object_helper.rb
@@ -230,7 +230,7 @@ module MiniAutobot
       def current_page(calling_page)
         calling_page.class.to_s.split('::').last.downcase
       end
-      
+
       private
 
       # @param  eg. (:css, 'button.cancel') or (*BUTTON_SUBMIT_SEARCH)
@@ -254,6 +254,18 @@ module MiniAutobot
         end
         @driver.manage.timeouts.implicit_wait = original_timeout
         result
+      end
+
+      # Method that overrides click to send the enter key to the element if the current browser
+      # is internet explorer. Used when sending the enter key to the element will work
+      def ie_safe_click(element)
+        driver.browser == :internet_explorer ? element.send_keys(:enter) : element.click
+      end
+
+      # Method that overrides click to send the space key to the checkbox if the current browser
+      # is internet explorer. Used when sending the space key to the checkbox will work
+      def ie_safe_checkbox_click(element)
+        driver.browser == :internet_explorer ? element.send_keys(:space) : element.click
       end
 
     end

--- a/lib/selenium/webdriver/common/element_mini.rb
+++ b/lib/selenium/webdriver/common/element_mini.rb
@@ -5,10 +5,12 @@ module Selenium
 
     class Element
 
+      # Click in a way that is reliable for IE and works for other browsers as well
       def ie_safe_click
         bridge.browser == :internet_explorer ? send_keys(:enter) : click
       end
 
+      # Click in a way that is reliable for IE and works for other browsers as well
       def ie_safe_checkbox_click
         bridge.browser == :internet_explorer ? send_keys(:space) : click
       end

--- a/lib/selenium/webdriver/common/element_mini.rb
+++ b/lib/selenium/webdriver/common/element_mini.rb
@@ -6,13 +6,13 @@ module Selenium
     class Element
 
       # Click in a way that is reliable for IE and works for other browsers as well
-      def ie_safe_click
+      def browser_safe_click
         bridge.browser == :internet_explorer ? send_keys(:enter) : click
       end
 
-      # Click in a way that is reliable for IE and works for other browsers as well
-      def ie_safe_checkbox_click
-        bridge.browser == :internet_explorer ? send_keys(:space) : click
+      # Click in a way that is reliable for IE and Firefox and works for other browsers as well
+      def browser_safe_checkbox_click
+        (bridge.browser == :internet_explorer || bridge.browser == :firefox) ? send_keys(:space) : click
       end
 
     end

--- a/lib/selenium/webdriver/common/element_mini.rb
+++ b/lib/selenium/webdriver/common/element_mini.rb
@@ -1,0 +1,18 @@
+require 'selenium-webdriver'
+
+module Selenium
+  module WebDriver
+
+    ##
+    # Monkey Patch to add ie_safe_click method to webdriver
+    #
+    class Element
+
+      def ie_safe_click
+        bridge.browser == :internet_explorer ? send_keys(:enter) : click
+      end
+
+    end
+
+  end
+end

--- a/lib/selenium/webdriver/common/element_mini.rb
+++ b/lib/selenium/webdriver/common/element_mini.rb
@@ -3,13 +3,14 @@ require 'selenium-webdriver'
 module Selenium
   module WebDriver
 
-    ##
-    # Monkey Patch to add ie_safe_click method to webdriver
-    #
     class Element
 
       def ie_safe_click
         bridge.browser == :internet_explorer ? send_keys(:enter) : click
+      end
+
+      def ie_safe_checkbox_click
+        bridge.browser == :internet_explorer ? send_keys(:space) : click
       end
 
     end


### PR DESCRIPTION
Adds browser_safe_click(element) and browser_safe_checkbox_click(element) to page_object_helper

Monkey Patch browser_safe_click and browser_safe_checkbox_click into Selenium::WebDriver::Element

Usages:

browser_safe_click(element)
element.browser_safe_click

https://www.pivotaltracker.com/story/show/111704448
