### PR TITLE
Ph/page object element container

### DIFF
--- a/lib/mini_autobot/page_objects.rb
+++ b/lib/mini_autobot/page_objects.rb
@@ -17,6 +17,7 @@ module MiniAutobot
 end
 
 # Major classes and modules
+require_relative 'page_objects/element_container'
 require_relative 'page_objects/base'
 require_relative 'page_objects/overlay/base'
 require_relative 'page_objects/widgets/base'

--- a/lib/mini_autobot/page_objects/base.rb
+++ b/lib/mini_autobot/page_objects/base.rb
@@ -17,6 +17,7 @@ module MiniAutobot
       include Utils::Loggable
       include Utils::PageObjectHelper
       include Utils::OverlayAndWidgetHelper
+      extend ElementContainer
 
       attr_accessor :assertions
       attr_accessor :failures
@@ -42,6 +43,14 @@ module MiniAutobot
 
         @assertions = 0
         @failures   = []
+      end
+
+      def find_first(how, what)
+        driver.find_element(how, what)
+      end
+
+      def find_all(how, what)
+        driver.all(how, what)
       end
 
       # Returns the current path loaded in the driver.

--- a/lib/mini_autobot/page_objects/element_container.rb
+++ b/lib/mini_autobot/page_objects/element_container.rb
@@ -2,20 +2,18 @@ module MiniAutobot
   module PageObjects
   	module ElementContainer
 
-	    def element(element_name, *find_args)
-	      build element_name, *find_args do
-	        define_method element_name.to_s do |*runtime_args, &element_block|
-	          self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
-	          find_first(*find_args, *runtime_args)
+	    def element(element_name, find_args)
+	      build element_name, find_args do
+	        define_method element_name.to_s do
+            find_first(*find_args)
 	        end
 	      end
 	    end
 
-	    def elements(collection_name, *find_args)
-	      build collection_name, *find_args do
-	        define_method collection_name.to_s do |*runtime_args, &element_block|
-	          self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
-	          find_all(*find_args, *runtime_args)
+	    def elements(collection_name, find_args)
+	      build collection_name, find_args do
+	        define_method collection_name.to_s do
+            find_all(*find_args)
 	        end
 	      end
 	    end
@@ -26,14 +24,9 @@ module MiniAutobot
 	      @mapped_items << item.to_s
 	    end
 
-	    def raise_if_block(obj, name, has_block)
-	      return unless has_block
-	      fail SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
-	    end
-
 	    private
 
-	    def build(name, *find_args)
+	    def build(name, find_args)
 	      if find_args.empty?
 	        create_no_selector name
 	      else

--- a/lib/mini_autobot/page_objects/element_container.rb
+++ b/lib/mini_autobot/page_objects/element_container.rb
@@ -2,18 +2,18 @@ module MiniAutobot
   module PageObjects
   	module ElementContainer
 
-	    def element(element_name, find_args)
-	      build element_name, find_args do
+	    def element(element_name, *find_args)
+	      build element_name, *find_args do |how, what|
 	        define_method element_name.to_s do
-            find_first(*find_args)
+            find_first(how, what)
 	        end
 	      end
 	    end
 
-	    def elements(collection_name, find_args)
-	      build collection_name, find_args do
+	    def elements(collection_name, *find_args)
+	      build collection_name, *find_args do |how, what|
 	        define_method collection_name.to_s do
-            find_all(*find_args)
+            find_all(how, what)
 	        end
 	      end
 	    end
@@ -26,12 +26,16 @@ module MiniAutobot
 
 	    private
 
-	    def build(name, find_args)
+	    def build(name, *find_args)
 	      if find_args.empty?
 	        create_no_selector name
 	      else
 	        add_to_mapped_items name
-	        yield
+	        if find_args.size == 1
+		        yield(:css, *find_args)
+		      else
+            yield(*find_args)
+		      end
 	      end
 	    end
 

--- a/lib/mini_autobot/page_objects/element_container.rb
+++ b/lib/mini_autobot/page_objects/element_container.rb
@@ -1,0 +1,53 @@
+module MiniAutobot
+  module PageObjects
+  	module ElementContainer
+
+	    def element(element_name, *find_args)
+	      build element_name, *find_args do
+	        define_method element_name.to_s do |*runtime_args, &element_block|
+	          self.class.raise_if_block(self, element_name.to_s, !element_block.nil?)
+	          find_first(*find_args, *runtime_args)
+	        end
+	      end
+	    end
+
+	    def elements(collection_name, *find_args)
+	      build collection_name, *find_args do
+	        define_method collection_name.to_s do |*runtime_args, &element_block|
+	          self.class.raise_if_block(self, collection_name.to_s, !element_block.nil?)
+	          find_all(*find_args, *runtime_args)
+	        end
+	      end
+	    end
+	    alias_method :collection, :elements
+
+	    def add_to_mapped_items(item)
+	      @mapped_items ||= []
+	      @mapped_items << item.to_s
+	    end
+
+	    def raise_if_block(obj, name, has_block)
+	      return unless has_block
+	      fail SitePrism::UnsupportedBlock, "#{obj.class}##{name} does not accept blocks, did you mean to define a (i)frame?"
+	    end
+
+	    private
+
+	    def build(name, *find_args)
+	      if find_args.empty?
+	        create_no_selector name
+	      else
+	        add_to_mapped_items name
+	        yield
+	      end
+	    end
+
+	    def create_no_selector(method_name)
+	      define_method method_name do
+	        fail MiniAutobot::NoSelectorForElement.new, "#{self.class.name} => :#{method_name} needs a selector"
+	      end
+	    end
+
+	  end
+	end
+end

--- a/lib/mini_autobot/page_objects/element_container.rb
+++ b/lib/mini_autobot/page_objects/element_container.rb
@@ -4,18 +4,18 @@ module MiniAutobot
 
       def element(element_name, *find_args)
         build element_name, *find_args do |how, what|
-                            define_method element_name.to_s do
-                              find_first(how, what)
-                            end
-                          end
+          define_method element_name.to_s do
+            find_first(how, what)
+          end
+        end
       end
 
       def elements(collection_name, *find_args)
         build collection_name, *find_args do |how, what|
-                               define_method collection_name.to_s do
-                                 find_all(how, what)
-                               end
-                             end
+          define_method collection_name.to_s do
+            find_all(how, what)
+          end
+        end
       end
       alias_method :collection, :elements
 

--- a/lib/mini_autobot/page_objects/element_container.rb
+++ b/lib/mini_autobot/page_objects/element_container.rb
@@ -1,50 +1,50 @@
 module MiniAutobot
   module PageObjects
-  	module ElementContainer
+    module ElementContainer
 
-	    def element(element_name, *find_args)
-	      build element_name, *find_args do |how, what|
-	        define_method element_name.to_s do
-            find_first(how, what)
-	        end
-	      end
-	    end
+      def element(element_name, *find_args)
+        build element_name, *find_args do |how, what|
+                            define_method element_name.to_s do
+                              find_first(how, what)
+                            end
+                          end
+      end
 
-	    def elements(collection_name, *find_args)
-	      build collection_name, *find_args do |how, what|
-	        define_method collection_name.to_s do
-            find_all(how, what)
-	        end
-	      end
-	    end
-	    alias_method :collection, :elements
+      def elements(collection_name, *find_args)
+        build collection_name, *find_args do |how, what|
+                               define_method collection_name.to_s do
+                                 find_all(how, what)
+                               end
+                             end
+      end
+      alias_method :collection, :elements
 
-	    def add_to_mapped_items(item)
-	      @mapped_items ||= []
-	      @mapped_items << item.to_s
-	    end
+      def add_to_mapped_items(item)
+        @mapped_items ||= []
+        @mapped_items << item.to_s
+      end
 
-	    private
+      private
 
-	    def build(name, *find_args)
-	      if find_args.empty?
-	        create_no_selector name
-	      else
-	        add_to_mapped_items name
-	        if find_args.size == 1
-		        yield(:css, *find_args)
-		      else
+      def build(name, *find_args)
+        if find_args.empty?
+          create_no_selector name
+        else
+          add_to_mapped_items name
+          if find_args.size == 1
+            yield(:css, *find_args)
+          else
             yield(*find_args)
-		      end
-	      end
-	    end
+          end
+        end
+      end
 
-	    def create_no_selector(method_name)
-	      define_method method_name do
-	        fail MiniAutobot::NoSelectorForElement.new, "#{self.class.name} => :#{method_name} needs a selector"
-	      end
-	    end
+      def create_no_selector(method_name)
+        define_method method_name do
+          fail MiniAutobot::NoSelectorForElement.new, "#{self.class.name} => :#{method_name} needs a selector"
+        end
+      end
 
-	  end
-	end
+    end
+  end
 end

--- a/lib/mini_autobot/page_objects/overlay/base.rb
+++ b/lib/mini_autobot/page_objects/overlay/base.rb
@@ -9,6 +9,7 @@ module MiniAutobot
         include Utils::Castable
         include Utils::PageObjectHelper
         include Utils::OverlayAndWidgetHelper
+        extend ElementContainer
 
         attr_reader :driver
 
@@ -23,6 +24,14 @@ module MiniAutobot
         ## for overlay that include Utils::OverlayAndWidgetHelper
         def page_object
           @page
+        end
+
+        def find_first(how, what)
+          driver.find_element(how, what)
+        end
+
+        def find_all(how, what)
+          driver.all(how, what)
         end
 
         # By default, any driver state is accepted for any page. This method

--- a/lib/mini_autobot/page_objects/widgets/base.rb
+++ b/lib/mini_autobot/page_objects/widgets/base.rb
@@ -9,6 +9,7 @@ module MiniAutobot
         include Utils::Castable
         include Utils::PageObjectHelper
         include Utils::OverlayAndWidgetHelper
+        extend ElementContainer
 
         attr_reader :driver, :element, :page
 
@@ -23,8 +24,13 @@ module MiniAutobot
           @page
         end
 
-        attr_reader :driver
-        attr_reader :element
+        def find_first(how, what)
+          element.find_element(how, what)
+        end
+
+        def find_all(how, what)
+          element.all(how, what)
+        end
 
         # Explicitly wait for a certain condition to be true:
         #   wait.until { driver.find_element(:css, 'body.tmpl-srp') }


### PR DESCRIPTION
[[PH][104021620] Better page object model](https://www.pivotaltracker.com/story/show/104021620)

Make `page_objects/base`, `overlay/base` and `widgets/base` extend a new module `ElementContainer` which adds methods to locate and access web elements, with locator `:css` by default and can optionally use other locators.

**Usage Examples**

```
element :lead_form_modal, 'div#lead-form-modal-popup'
```

or

```
element :lead_form_modal, :xpath, "//div[@id='lead-form-modal-popup']"
```

gives you a method `lead_form_modal` which returns a web element.
