### PR TITLE
Ph/remove redundant tap

### DIFF
--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -102,6 +102,8 @@ module MiniAutobot
           if @@runnables_count == mini_autobot_runnables.size
             parallel = Parallel.new(MiniAutobot.settings.parallel, @@selected_methods)
             parallel.run_in_parallel!
+            parallel.remove_redundant_tap if MiniAutobot.settings.rerun_failure
+            exit
           end
 
           return [] # no test will run

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -101,6 +101,7 @@ module MiniAutobot
 
           if @@runnables_count == mini_autobot_runnables.size
             parallel = Parallel.new(MiniAutobot.settings.parallel, @@selected_methods)
+            parallel.clean_result!
             parallel.run_in_parallel!
             parallel.remove_redundant_tap if MiniAutobot.settings.rerun_failure
             exit


### PR DESCRIPTION
[[PH][112920155] Remove redundant tap result files after rerun](https://www.pivotaltracker.com/story/show/112920155)
1. `remove_redundant_tap` to cleanup duplicate tap results for parallel run when rerun is enabled;
2. `run_in_parallel!` doesn't exit the program anymore;
3. abstract `result_dir` to instance variable to be shared by different methods in parallel, also, in the future, this value will be configurable.
