### PR TITLE
Ph/aggregate tap results

### DIFF
--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -78,7 +78,9 @@ module MiniAutobot
         }
         result_stats_line_start = '  # 1 tests:'
         result_file.puts "1..#{results_count}"
+        file_count = 0
         Dir.glob("#{@result_dir}/*.t") do |filename|
+          file_count += 1
           File.open(filename, 'r') do |file|
             breakpoint_line = 0
             file.each_with_index do |line, index|
@@ -97,7 +99,12 @@ module MiniAutobot
               elsif line.strip == '#'
                 next
               else
-                result_file.puts line
+                if line.start_with?('ok 1') || line.start_with?('not ok 1')
+                  line_begin, line_end = line.split('1 -')
+                  result_file.puts [line_begin, line_end].join("#{file_count} -")
+                else
+                  result_file.puts line
+                end
               end
             end
           end

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -68,7 +68,7 @@ module MiniAutobot
 
     def aggregate_tap_results
       results_count = Dir.glob("#{@result_dir}/*.t").size
-      File.open("#{@result_dir}/test_aggregated_result", 'a+') do |result_file|
+      File.open("#{@result_dir}/test_aggregated_result.tap", 'a+') do |result_file|
         result_stats = {
             'pass' => 0,
             'fail' => 0,

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -113,6 +113,8 @@ module MiniAutobot
         result_file.puts '  #'
         result_file.puts "  # #{results_count} tests: #{result_stats['pass']} pass, #{result_stats['fail']} fail, #{result_stats['errs']} errs, #{result_stats['todo']} todo, #{result_stats['omit']} omit"
         result_file.puts "  # [00:00:00.00 0.00t/s 00.0000s/t] Finished at: #{Time.now}"
+        total_ok = result_stats['pass'] + result_stats['omit']
+        result_file.puts "^[]#{total_ok};[Minitest results] #{results_count} tests (#{result_stats['omit']} skipped)^G"
       end
     end
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -68,7 +68,7 @@ module MiniAutobot
 
     def aggregate_tap_results
       results_count = Dir.glob("#{@result_dir}/*.t").size
-      File.open('aggregated_result', 'a+') do |result_file|
+      File.open('test_aggregated_result', 'a+') do |result_file|
         result_file.puts "1..#{results_count}"
         Dir.glob("#{@result_dir}/*.t") do |filename|
           File.open(filename, 'r') do |file|
@@ -77,6 +77,7 @@ module MiniAutobot
               result_file.puts line
             end
           end
+          File.delete(filename)
         end
       end
     end

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -66,6 +66,21 @@ module MiniAutobot
       end
     end
 
+    def aggregate_tap_results
+      results_count = Dir.glob("#{@result_dir}/*.t").size
+      File.open('aggregated_result', 'a+') do |result_file|
+        result_file.puts "1..#{results_count}"
+        Dir.glob("#{@result_dir}/*.t") do |filename|
+          File.open(filename, 'r') do |file|
+            file.each_with_index do |line, index|
+              next if index == 0
+              result_file.puts line
+            end
+          end
+        end
+      end
+    end
+
     def count_autobot_process
       counting_process_output = IO.popen "ps -ef | grep 'bin/#{@static_run_command}' -c"
       counting_process_output.readlines[0].to_i - 1 # minus grep process

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -68,7 +68,7 @@ module MiniAutobot
 
     def aggregate_tap_results
       results_count = Dir.glob("#{@result_dir}/*.t").size
-      File.open('test_aggregated_result', 'a+') do |result_file|
+      File.open("#{@result_dir}/test_aggregated_result", 'a+') do |result_file|
         result_file.puts "1..#{results_count}"
         Dir.glob("#{@result_dir}/*.t") do |filename|
           File.open(filename, 'r') do |file|

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -113,8 +113,6 @@ module MiniAutobot
         result_file.puts '  #'
         result_file.puts "  # #{results_count} tests: #{result_stats['pass']} pass, #{result_stats['fail']} fail, #{result_stats['errs']} errs, #{result_stats['todo']} todo, #{result_stats['omit']} omit"
         result_file.puts "  # [00:00:00.00 0.00t/s 00.0000s/t] Finished at: #{Time.now}"
-        total_ok = result_stats['pass'] + result_stats['omit']
-        result_file.puts "^[]#{total_ok};[Minitest results] #{results_count} tests (#{result_stats['omit']} skipped)^G"
       end
     end
 

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -66,6 +66,9 @@ module MiniAutobot
       end
     end
 
+    # Aggregate all individual test_*.t files
+    # replace them with one file - test_aggregated_result.tap
+    # so they will be considered as one test plan by tap result parser
     def aggregate_tap_results
       results_count = Dir.glob("#{@result_dir}/*.t").size
       File.open("#{@result_dir}/test_aggregated_result.tap", 'a+') do |result_file|

--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -110,7 +110,9 @@ module MiniAutobot
           end
           File.delete(filename)
         end
+        result_file.puts '  #'
         result_file.puts "  # #{results_count} tests: #{result_stats['pass']} pass, #{result_stats['fail']} fail, #{result_stats['errs']} errs, #{result_stats['todo']} todo, #{result_stats['omit']} omit"
+        result_file.puts "  # [00:00:00.00 0.00t/s 00.0000s/t] Finished at: #{Time.now}"
       end
     end
 

--- a/lib/mini_autobot/test_case.rb
+++ b/lib/mini_autobot/test_case.rb
@@ -104,6 +104,7 @@ module MiniAutobot
             parallel.clean_result!
             parallel.run_in_parallel!
             parallel.remove_redundant_tap if MiniAutobot.settings.rerun_failure
+            parallel.aggregate_tap_results
             exit
           end
 


### PR DESCRIPTION
[[PH][112940093] Aggregate tap results](https://www.pivotaltracker.com/story/show/112940093)

Aggregate all individual `test_*.t` files after parallel run, replace them with one file - `test_aggregated_result.tap`, so they will be considered as one test plan by tap result parser, eg. tap plugin on jenkins.
