### PR TITLE
jt/mobile-google-sheets

### DIFF
--- a/lib/mini_autobot/google_sheets.rb
+++ b/lib/mini_autobot/google_sheets.rb
@@ -68,15 +68,28 @@ module MiniAutobot
       desired_browser_string = nil
       case connector
       when /chrome/
-        desired_browser_string = 'Chrome'
+        desired_browser_string = 'Chrome (Automated)'
       when /ff/
-        desired_browser_string = 'FF'
+        desired_browser_string = 'FF (Automated)'
       when /firefox/
-        desired_browser_string = 'FF'
+        desired_browser_string = 'FF (Automated)'
       when /ie11/
-        desired_browser_string = 'IE11'
+        desired_browser_string = 'IE11 (Automated)'
+      when /iphone/
+        desired_browser_string = 'iPhone (Automated)'
+      when /android/
+        desired_browser_string = 'Android (Automated)'
       end
-      (1..@worksheet.num_cols).find { |col| @worksheet[1, col] == desired_browser_string }
+      column = (1..@worksheet.num_cols).find { |col| @worksheet[1, col] == desired_browser_string }
+      if column.nil?
+        create_column(desired_browser_string)
+        column = (1..@worksheet.num_cols).find { |col| @worksheet[1, col] == desired_browser_string }
+      end
+      column
+    end
+
+    def create_column(desired_browser_string)
+      @worksheet[1, @worksheet.num_cols] = desired_browser_string
     end
 
     def target_rows(key)


### PR DESCRIPTION
This PR does a couple things

1 - It adds support for automated mobile device tests to update columns (one for android, one for iPhone)

2 - If it doesn't find a column for the browser, it adds one - this way, we will always get the results added to the sheets and shouldn't get failures caused by tests failing to find a correctly named browser column

https://www.pivotaltracker.com/story/show/128412141
