### PR TITLE
Jt/cli feature flipping

### DIFF
--- a/lib/mini_autobot/parallel.rb
+++ b/lib/mini_autobot/parallel.rb
@@ -24,6 +24,9 @@ module MiniAutobot
       if MiniAutobot.settings.google_sheets?
         @static_run_command += " -g #{MiniAutobot.settings.google_sheet}"
       end
+      if MiniAutobot.settings.feature_flips
+        @static_run_command += " -f #{MiniAutobot.settings.feature_flips}"
+      end
       tap_reporter_path = MiniAutobot.gem_root.join('lib/tapout/custom_reporters/fancy_tap_reporter.rb')
       @pipe_tap = "--tapy | tapout --no-color -r #{tap_reporter_path.to_s} fancytap"
     end

--- a/lib/mini_autobot/settings.rb
+++ b/lib/mini_autobot/settings.rb
@@ -101,6 +101,10 @@ module MiniAutobot
       hsh[:google_sheets]
     end
 
+    def feature_flips
+      hsh[:feature_flips]
+    end
+
     private
     attr_reader :hsh
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,7 +84,7 @@ module Minitest
       options[:google_sheets] = value
     end
 
-    options[:feautre_flips] = []
+    options[:feautre_flips] = Array.new
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
       options[:feature_flips].insert(value)
     end

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -86,7 +86,7 @@ module Minitest
 
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
       options[:feature_flips] = []
-      options[:feature_flips] << value.to_s.split(',').map(&:to_sym)
+      value.to_s.split(',').each { |feature| options[:feature_flips] << feature.to_sym }
     end
   end
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -86,7 +86,7 @@ module Minitest
 
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
       options[:feature_flips] = []
-      options[:feature_flips] << value.to_s.split(',').map { |f| f.to_sym }
+      options[:feature_flips] << value.to_s.split(',').map(&:to_sym)
     end
   end
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -83,6 +83,11 @@ module Minitest
     parser.on('-g', '--google-sheets SHEET', 'Report results to specified Google Sheets spreadsheet') do |value|
       options[:google_sheets] = value
     end
+
+    options[:feautre_flips] = []
+    parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
+      options[:feature_flips].insert(value)
+    end
   end
 
 end

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,9 +84,9 @@ module Minitest
       options[:google_sheets] = value
     end
 
-    options[:feature_flips] = []
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
-      options[:feature_flips].insert(value)
+      options[:feature_flips] = []
+      options[:feature_flips] << value.to_s.split(',').map { |f| f.to_sym }
     end
   end
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,9 +84,9 @@ module Minitest
       options[:google_sheets] = value
     end
 
-    options[:feature_flips] = []
+    options[:feature_flips] = false
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
-      value.to_s.split(',').each { |feature| options[:feature_flips] << feature.to_sym }
+      options[:feature_flips] = value
     end
   end
 

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,8 +84,8 @@ module Minitest
       options[:google_sheets] = value
     end
 
+    options[:feature_flips] = []
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
-      options[:feature_flips] = []
       value.to_s.split(',').each { |feature| options[:feature_flips] << feature.to_sym }
     end
   end

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,7 +84,7 @@ module Minitest
       options[:google_sheets] = value
     end
 
-    options[:feautre_flips] = Array.new
+    options[:feature_flips] = []
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
       options[:feature_flips].insert(value)
     end


### PR DESCRIPTION
This PR enables feature flipping to be controlled from the command line. Pass each feature that you want to turn on separated by commas like so:

bundle exec mini_autobot -c chrome -e ag_qa -n test_name -f feature1,feature2

Important notes:
- Don't put spaces between features
- This will require updates to our tests and page objects as follows:

Old Syntax:
if FeatureFlipSettings::FEATURE_FLIPS[:ui_redesign].include? MiniAutobot.settings.env
 do stuff
end

New Syntax:
if MiniAutobot.settings.feature_flips.include?('ui_redesign')
 do stuff
end

https://www.pivotaltracker.com/story/show/128455687
