### PR TITLE
jt/fix-google-sheets

### DIFF
--- a/lib/mini_autobot/google_sheets.rb
+++ b/lib/mini_autobot/google_sheets.rb
@@ -89,7 +89,7 @@ module MiniAutobot
     end
 
     def create_column(desired_browser_string)
-      @worksheet[1, @worksheet.num_cols] = desired_browser_string
+      @worksheet[1, (@worksheet.num_cols + 1)] = desired_browser_string
     end
 
     def target_rows(key)

--- a/lib/mini_autobot/version.rb
+++ b/lib/mini_autobot/version.rb
@@ -1,3 +1,3 @@
 module MiniAutobot
-  VERSION = '1.1.2'
+  VERSION = '1.1.3'
 end


### PR DESCRIPTION
This is a quick PR - it changes the method that creates a new column for the browser when none is found to go 1 beyond the current number of columns, fixing a bug where it was overwriting the furthest column to the right

https://www.pivotaltracker.com/story/show/128528795
