### PR TITLE
[JT][128575285] Fix feature flipping CLI setting

### DIFF
--- a/lib/mini_autobot/version.rb
+++ b/lib/mini_autobot/version.rb
@@ -1,3 +1,3 @@
 module MiniAutobot
-  VERSION = '1.1.3'
+  VERSION = '1.1.4'
 end

--- a/lib/minitest/autobot_settings_plugin.rb
+++ b/lib/minitest/autobot_settings_plugin.rb
@@ -84,7 +84,7 @@ module Minitest
       options[:google_sheets] = value
     end
 
-    options[:feature_flips] = false
+    options[:feature_flips] = ''
     parser.on('-f', '--feature-flips FEATURE', 'Flip tests to run against a different feature set') do |value|
       options[:feature_flips] = value
     end


### PR DESCRIPTION
Switch the default setting for feature flipping from false to an empty string. Fixes the issue with includes? checks failing if no flips were passed in

https://www.pivotaltracker.com/story/show/128575285
